### PR TITLE
Fixed your responsive header issue on chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # roosdebildt.github.io
+
+:)

--- a/blog/index.html
+++ b/blog/index.html
@@ -8,8 +8,10 @@
 	</head>
 	<body>
 		<div class="container">
-			<header>
-				<h1>SUPER BLOG</h1>
+			<header class="clearfix">
+				<div class="nav-title">
+					<h1>SUPER BLOG</h1>
+				</div>
 				<nav>
 					<ul>
 						<li><a href="about.html">about</a></li>
@@ -18,7 +20,7 @@
 					</ul>
 				</nav>
 			</header>
-			<section class="latest">
+			<section class="latest clearfix">
 				<ul>
 					<li>The quick, brown fox jumps over a lazy dog</li>
 					<li>Jolt my wax bed</li>
@@ -33,7 +35,7 @@
 			<div class="main">
 				<article>
 					<h3>Feb 13, 2013</h3>
-					<h2>THE QUICK, BROWN FOX JUMPS OVER A LAZY DOG.</h2>
+					<h2>THE QUICK, BROWN FOX JUMPS OVER A PAIR OF WOODEN SHOES.</h2>
 					<p>DJs flock by when MTV ax quiz prog. Junk MTV quiz graced by fox whelps. Bawds jog, flick quartz, vex nymphs. Waltz, bad nymph, for quick jigs vex! Fox nymphs grab quick-jived waltz. Brick quiz whangs jumpy veldt fox. Bright vixens jump; dozy fowl quack. Quick wafting zephyrs vex bold Jim. Quick zephyrs blow, vexing daft Jim. Sex-charged fop blew my junk TV quiz. How quickly daft jumping zebras vex. Two driven jocks help fax my big quiz. Quick, Baz, get my woven flax jodhpurs! “Now fax quiz Jack! “ my brave ghost pled. Five quacking zephyrs jolt my wax bed. Flummoxed by job, kvetching W. zaps Iraq. Cozy sphinx waves quart jug of bad milk.
 					</p>
 				</article>

--- a/blog/style.css
+++ b/blog/style.css
@@ -17,6 +17,9 @@ article, aside, canvas, details, embed,
 figure, figcaption, footer, header, hgroup, 
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 	margin: 0;
 	padding: 0;
 	border: 0;
@@ -97,7 +100,12 @@ a {
 
 nav li {
 	display: inline-block;
-	margin-right: 3%;
+	margin-left: 2rem; /* using a rem value rather than percentage */
+}
+
+/* sweet trick alert: look up nth-child */
+nav li:first-child {
+	margin-left: 0; /* this means the first appearence of this element will have this value */
 }
 
 header, article {
@@ -117,10 +125,25 @@ footer {
 	border-top: 2px solid black;
 }
 
+/*
+ * MODULES
+   (add here classes that are re-usable and not specific to a single layout element)
+ */
+
+.clearfix:after { 
+   content: " ";
+   display: block; 
+   height: 0; 
+   clear: both;
+}
+
 /* media queries */
 
 @media screen and (min-width: 1000px) {
 
+	/*
+	 *  BASE
+	 */
 	.container {
 		width: 95%;
 	}
@@ -135,18 +158,35 @@ footer {
 		margin-bottom: 2%;
 	}
 
+
+	/*
+	 *  LAYOUT
+	 */
+
+	.nav-title {
+		position: relative;
+		width: 50%;
+		float: left;
+	}
+
 	nav {
 		text-align: right;
-		width: 30%;
-		float: right;
+		width: 50%;
+		float: left;
 		margin-top: 91.25px;
 	}
 
 	header {
-	border-bottom: 2px solid black;
+		clear: both;
+		width: 100%;
+		border-bottom: 2px solid black;
 	}
 
 	/* in chrome, for some reason, the nav pops up underneath the bottom-bordr. but, when you refresh, it ends up above, huuhhhh? */
+
+	section {
+		clear: both;
+	}
 
 	.latest {
 		display: block;
@@ -163,3 +203,8 @@ footer {
 		max-width: 75em;
 	}
 }
+
+ /* For debugging only */
+/** {
+	border: 1px solid green !important;
+}*/


### PR DESCRIPTION
First, I used the `box-sizing: border-box;` CSS3 property. This is very helpful and seems to be pretty commonly accepted by now.
Second, I added a wrapper around your header `H1`. That way, I can be sure it will be a certain width independent of the size of my `H1`.
Then, I made sure both elements were floated left, instead of using `float: right;`. I also added a clearfix to the header to make sure the next piece of content doesn't try to float upwards.

Looks good!

Make sure you check the code for little things I added.

Great job, and great eye.